### PR TITLE
Add migrations.cleanup.enabled and migrations.cleanup.keepVersions to automatically cleanup old kibana indices on upgrade

### DIFF
--- a/src/core/server/saved_objects/migrations/core/index.ts
+++ b/src/core/server/saved_objects/migrations/core/index.ts
@@ -29,7 +29,7 @@
  */
 
 export { DocumentMigrator } from './document_migrator';
-export { IndexMigrator } from './index_migrator';
+export { IndexMigrator, CleanupConfig } from './index_migrator';
 export { buildActiveMappings } from './build_active_mappings';
 export { CallCluster } from './call_cluster';
 export { LogFn, SavedObjectsMigrationLogger } from './migration_logger';

--- a/src/core/server/saved_objects/migrations/core/index_migrator.test.ts
+++ b/src/core/server/saved_objects/migrations/core/index_migrator.test.ts
@@ -773,6 +773,58 @@ describe('IndexMigrator', () => {
       `"error migrating document"`
     );
   });
+
+  describe('cleanup old indices', () => {
+    test('calls deleteOldIndices when cleanup is enabled and migration succeeds', async () => {
+      const { client } = testOpts;
+
+      testOpts.documentMigrator.migrationVersion = { dashboard: '2.4.5' };
+
+      withIndex(client, { numOutOfDate: 1 });
+
+      // Mock for deleteOldIndices - no old indices to delete
+      client.indices.get.mockResolvedValueOnce(
+        opensearchClientMock.createSuccessTransportRequestPromise({}, { statusCode: 404 })
+      );
+
+      await new IndexMigrator(testOpts, { enabled: true, keepVersions: 1 }).migrate();
+
+      // Verify deleteOldIndices was called (indices.get with wildcard pattern)
+      expect(client.indices.get).toHaveBeenCalledWith({ index: '.kibana_*' }, { ignore: [404] });
+    });
+
+    test('does not call deleteOldIndices when cleanup is disabled', async () => {
+      const { client } = testOpts;
+
+      testOpts.documentMigrator.migrationVersion = { dashboard: '2.4.5' };
+
+      withIndex(client, { numOutOfDate: 1 });
+
+      await new IndexMigrator(testOpts, { enabled: false, keepVersions: 1 }).migrate();
+
+      // Verify deleteOldIndices was NOT called
+      expect(client.indices.get).not.toHaveBeenCalledWith(
+        { index: '.kibana_*' },
+        { ignore: [404] }
+      );
+    });
+
+    test('does not call deleteOldIndices when no cleanup config provided', async () => {
+      const { client } = testOpts;
+
+      testOpts.documentMigrator.migrationVersion = { dashboard: '2.4.5' };
+
+      withIndex(client, { numOutOfDate: 1 });
+
+      await new IndexMigrator(testOpts).migrate();
+
+      // Verify deleteOldIndices was NOT called
+      expect(client.indices.get).not.toHaveBeenCalledWith(
+        { index: '.kibana_*' },
+        { ignore: [404] }
+      );
+    });
+  });
 });
 
 function withIndex(

--- a/src/core/server/saved_objects/migrations/core/index_migrator.ts
+++ b/src/core/server/saved_objects/migrations/core/index_migrator.ts
@@ -35,19 +35,27 @@ import { migrateRawDocs } from './migrate_raw_docs';
 import { Context, migrationContext, MigrationOpts } from './migration_context';
 import { coordinateMigration, MigrationResult } from './migration_coordinator';
 
+export interface CleanupConfig {
+  enabled: boolean;
+  keepVersions: number;
+}
+
 /*
  * Core logic for migrating the mappings and documents in an index.
  */
 export class IndexMigrator {
   private opts: MigrationOpts;
+  private cleanupConfig?: CleanupConfig;
 
   /**
    * Creates an instance of IndexMigrator.
    *
    * @param {MigrationOpts} opts
+   * @param {CleanupConfig} cleanupConfig
    */
-  constructor(opts: MigrationOpts) {
+  constructor(opts: MigrationOpts, cleanupConfig?: CleanupConfig) {
     this.opts = opts;
+    this.cleanupConfig = cleanupConfig;
   }
 
   /**
@@ -58,6 +66,7 @@ export class IndexMigrator {
    */
   public async migrate(): Promise<MigrationResult> {
     const context = await migrationContext(this.opts);
+    const cleanupConfig = this.cleanupConfig;
 
     return coordinateMigration({
       log: context.log,
@@ -70,7 +79,20 @@ export class IndexMigrator {
 
       async runMigration() {
         if (await requiresMigration(context)) {
-          return migrateIndex(context);
+          const result = await migrateIndex(context);
+
+          // Cleanup old indices after successful migration
+          if (cleanupConfig?.enabled && result.status === 'migrated') {
+            await Index.deleteOldIndices(
+              context.client,
+              context.dest.indexName,
+              context.alias,
+              cleanupConfig.keepVersions,
+              context.log
+            );
+          }
+
+          return result;
         }
 
         return { status: 'skipped' };

--- a/src/core/server/saved_objects/migrations/core/opensearch_index.test.ts
+++ b/src/core/server/saved_objects/migrations/core/opensearch_index.test.ts
@@ -592,6 +592,95 @@ describe('OpenSearchIndex', () => {
     });
   });
 
+  describe('deleteOldIndices', () => {
+    const mockLog = { info: jest.fn() };
+
+    beforeEach(() => {
+      mockLog.info.mockClear();
+    });
+
+    test('deletes indices older than keepVersions', async () => {
+      client.indices.get.mockResolvedValue(
+        opensearchClientMock.createSuccessTransportRequestPromise({
+          '.kibana_1': {},
+          '.kibana_2': {},
+          '.kibana_3': {},
+          '.kibana_4': {},
+        })
+      );
+      client.indices.delete.mockResolvedValue(
+        opensearchClientMock.createSuccessTransportRequestPromise({} as any)
+      );
+
+      const deleted = await Index.deleteOldIndices(client, '.kibana_4', '.kibana', 1, mockLog);
+
+      expect(deleted.sort()).toEqual(['.kibana_1', '.kibana_2']);
+      expect(client.indices.delete).toHaveBeenCalledWith({
+        index: expect.arrayContaining(['.kibana_1', '.kibana_2']),
+      });
+      expect(mockLog.info).toHaveBeenCalled();
+    });
+
+    test('keeps all versions when keepVersions covers them', async () => {
+      client.indices.get.mockResolvedValue(
+        opensearchClientMock.createSuccessTransportRequestPromise({
+          '.kibana_1': {},
+          '.kibana_2': {},
+        })
+      );
+
+      const deleted = await Index.deleteOldIndices(client, '.kibana_2', '.kibana', 1, mockLog);
+
+      expect(deleted).toEqual([]);
+      expect(client.indices.delete).not.toHaveBeenCalled();
+    });
+
+    test('handles 404 when no indices exist', async () => {
+      client.indices.get.mockResolvedValue(
+        opensearchClientMock.createSuccessTransportRequestPromise({}, { statusCode: 404 })
+      );
+
+      const deleted = await Index.deleteOldIndices(client, '.kibana_1', '.kibana', 1, mockLog);
+
+      expect(deleted).toEqual([]);
+    });
+
+    test('ignores indices that do not match version pattern', async () => {
+      client.indices.get.mockResolvedValue(
+        opensearchClientMock.createSuccessTransportRequestPromise({
+          '.kibana_1': {},
+          '.kibana_2': {},
+          '.kibana_task_manager_1': {},
+          '.kibana_other': {},
+        })
+      );
+      client.indices.delete.mockResolvedValue(
+        opensearchClientMock.createSuccessTransportRequestPromise({} as any)
+      );
+
+      const deleted = await Index.deleteOldIndices(client, '.kibana_2', '.kibana', 0, mockLog);
+
+      expect(deleted).toEqual(['.kibana_1']);
+    });
+
+    test('deletes all old indices when keepVersions is 0', async () => {
+      client.indices.get.mockResolvedValue(
+        opensearchClientMock.createSuccessTransportRequestPromise({
+          '.kibana_1': {},
+          '.kibana_2': {},
+          '.kibana_3': {},
+        })
+      );
+      client.indices.delete.mockResolvedValue(
+        opensearchClientMock.createSuccessTransportRequestPromise({} as any)
+      );
+
+      const deleted = await Index.deleteOldIndices(client, '.kibana_3', '.kibana', 0, mockLog);
+
+      expect(deleted.sort()).toEqual(['.kibana_1', '.kibana_2']);
+    });
+  });
+
   describe('migrationsUpToDate', () => {
     // A helper to reduce boilerplate in the hasMigration tests that follow.
     async function testMigrationsUpToDate({

--- a/src/core/server/saved_objects/migrations/core/opensearch_index.ts
+++ b/src/core/server/saved_objects/migrations/core/opensearch_index.ts
@@ -241,6 +241,57 @@ export async function deleteIndex(client: MigrationOpenSearchClient, index: stri
 }
 
 /**
+ * Deletes old migration indices, keeping the specified number of previous versions.
+ * For example, if keepVersions=1 and current index is .kibana_3, it will keep .kibana_2
+ * and delete .kibana_1 and any older indices.
+ *
+ * @param client - The OpenSearch client
+ * @param currentIndex - The current index name (e.g., '.kibana_3')
+ * @param alias - The alias name (e.g., '.kibana')
+ * @param keepVersions - Number of old versions to keep (default: 1)
+ * @param log - Logger for audit purposes
+ */
+export async function deleteOldIndices(
+  client: MigrationOpenSearchClient,
+  currentIndex: string,
+  alias: string,
+  keepVersions: number,
+  log: { info: (msg: string) => void }
+): Promise<string[]> {
+  const { body, statusCode } = await client.indices.get({ index: `${alias}_*` }, { ignore: [404] });
+
+  if (statusCode === 404 || !body) {
+    return [];
+  }
+
+  const indices = Object.keys(body)
+    .map((name) => {
+      const match = name.match(new RegExp(`^${escapeRegex(alias)}_(\\d+)$`));
+      return match ? { name, version: parseInt(match[1], 10) } : null;
+    })
+    .filter((item): item is { name: string; version: number } => item !== null)
+    .sort((a, b) => b.version - a.version);
+
+  const currentVersion = parseInt((currentIndex.match(/_(\d+)$/) || [])[1], 10) || 0;
+  const indicesToDelete = indices.filter((idx) => idx.version < currentVersion - keepVersions);
+
+  if (indicesToDelete.length === 0) {
+    return [];
+  }
+
+  const deleteNames = indicesToDelete.map((idx) => idx.name);
+  log.info(`Deleting old saved objects indices: ${deleteNames.join(', ')}`);
+
+  await client.indices.delete({ index: deleteNames });
+
+  return deleteNames;
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
  * Converts an index to an alias. The `alias` parameter is the desired alias name which currently
  * is a concrete index. This function will reindex `alias` into a new index, delete the `alias`
  * index, and then create an alias `alias` that points to the new index.

--- a/src/core/server/saved_objects/migrations/opensearch_dashboards/opensearch_dashboards_migrator.ts
+++ b/src/core/server/saved_objects/migrations/opensearch_dashboards/opensearch_dashboards_migrator.ts
@@ -172,27 +172,30 @@ export class OpenSearchDashboardsMigrator {
     });
 
     const migrators = Object.keys(indexMap).map((index) => {
-      return new IndexMigrator({
-        batchSize: this.savedObjectsConfig.batchSize,
-        client: this.client,
-        documentMigrator: this.documentMigrator,
-        index,
-        log: this.log,
-        mappingProperties: indexMap[index].typeMappings,
-        pollInterval: this.savedObjectsConfig.pollInterval,
-        scrollDuration: this.savedObjectsConfig.scrollDuration,
-        serializer: this.serializer,
-        // Only necessary for the migrator of the opensearch-dashboards index.
-        obsoleteIndexTemplatePattern:
-          index === opensearchDashboardsIndexName
-            ? 'opensearch_dashboards_index_template*'
+      return new IndexMigrator(
+        {
+          batchSize: this.savedObjectsConfig.batchSize,
+          client: this.client,
+          documentMigrator: this.documentMigrator,
+          index,
+          log: this.log,
+          mappingProperties: indexMap[index].typeMappings,
+          pollInterval: this.savedObjectsConfig.pollInterval,
+          scrollDuration: this.savedObjectsConfig.scrollDuration,
+          serializer: this.serializer,
+          // Only necessary for the migrator of the opensearch-dashboards index.
+          obsoleteIndexTemplatePattern:
+            index === opensearchDashboardsIndexName
+              ? 'opensearch_dashboards_index_template*'
+              : undefined,
+          typesToDelete: this.savedObjectsConfig.delete.enabled
+            ? this.savedObjectsConfig.delete.types
             : undefined,
-        typesToDelete: this.savedObjectsConfig.delete.enabled
-          ? this.savedObjectsConfig.delete.types
-          : undefined,
-        convertToAliasScript: indexMap[index].script,
-        opensearchDashboardsRawConfig: this.opensearchDashboardsRawConfig,
-      });
+          convertToAliasScript: indexMap[index].script,
+          opensearchDashboardsRawConfig: this.opensearchDashboardsRawConfig,
+        },
+        this.savedObjectsConfig.cleanup
+      );
     });
 
     return Promise.all(migrators.map((migrator) => migrator.migrate()));

--- a/src/core/server/saved_objects/saved_objects_config.ts
+++ b/src/core/server/saved_objects/saved_objects_config.ts
@@ -52,6 +52,10 @@ export const savedObjectsMigrationConfig = {
         },
       }
     ),
+    cleanup: schema.object({
+      enabled: schema.boolean({ defaultValue: false }),
+      keepVersions: schema.number({ defaultValue: 1, min: 0 }),
+    }),
   }),
 };
 


### PR DESCRIPTION
### Description

This PR adds an optional cleanup step to the saved objects migration process that automatically deletes old migration indices after a successful upgrade.

During OSD node upgrades, the migration system creates new concrete indices (e.g., `.kibana_1` → `.kibana_2` → `.kibana_3`) and flips the alias to point to the new index. Previously, all old indices were retained indefinitely, consuming cluster storage.

This change introduces configurable cleanup that:
- Keeps the current index and a configurable number of previous versions (default: 1) for rollback safety
- Deletes older indices (N-2 and below) automatically after successful migration
- Is opt-in by default (`migrations.cleanup.enabled: false`)
- Logs deleted indices for audit purposes
- Is multi-tenancy safe (only deletes versioned indices matching `{alias}_\d+` pattern, not tenant indices)

**Configuration options:**

```yaml
migrations:
  cleanup:
    enabled: true        # opt-in, default false
    keepVersions: 1      # number of old versions to retain, default 1
```

### Issues Resolved

Related to https://forum.opensearch.org/t/is-there-any-clean-up-process-for-internal-indexes-kibana-monitoring/23837

## Screenshot

N/A - No UI changes

## Testing the changes

Unit tests:

1. `yarn test:jest src/core/server/saved_objects/migrations/core/opensearch_index.test.ts --testNamePattern="deleteOldIndices"`
2. `yarn test:jest src/core/server/saved_objects/migrations/core/index_migrator.test.ts --testNamePattern="cleanup"`

Manual testing:

Set up a cluster with existing migration indices (e.g., .kibana_1, .kibana_2, .kibana_3)

Configure opensearch_dashboards.yml:

```
migrations:
  cleanup:
    enabled: true
    keepVersions: 1
```

Start OSD and trigger a migration (e.g., by adding a new saved object type or mapping change)

Verify:

1. New index is created (e.g., .kibana_4)
2. Previous index is retained (.kibana_3)
3. Older indices are deleted (.kibana_1, .kibana_2)

Also test with multi-tenancy from Security plugin

Verify opt-out behavior:

Set migrations.cleanup.enabled: false (or omit config entirely)

Trigger migration

Verify no indices are deleted

## Changelog

feat: Add optional cleanup of old saved objects migration indices

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Update [CHANGELOG.md](./../CHANGELOG.md)
- [ ] Commits are signed per the DCO using --signoff
