### PR TITLE
Preserve request context when loading data source credentials

### DIFF
--- a/src/plugins/data_source/server/client/configure_client.ts
+++ b/src/plugins/data_source/server/client/configure_client.ts
@@ -25,7 +25,7 @@ import {
   getAWSCredential,
   getCredential,
   getDataSource,
-  getDataSourceInternal,
+  getDataSourceWithCredentials,
   getAuthenticationMethod,
   generateCacheKey,
 } from './configure_client_utils';
@@ -35,7 +35,7 @@ export const configureClient = async (
   {
     dataSourceId,
     savedObjects,
-    internalSavedObjects,
+    credentialSavedObjects,
     cryptography,
     testClientDataSourceAttr,
     customApiSchemaRegistryPromise,
@@ -63,11 +63,11 @@ export const configureClient = async (
         ((type === AuthType.UsernamePasswordType && !credentials?.password) ||
           (type === AuthType.SigV4 && !credentials?.accessKey && !credentials?.secretKey))
       ) {
-        // Verify user can access the data source (scoped client enforces tenant/workspace permissions),
-        // then fetch with credentials via internal repository to avoid the credential-stripping wrapper.
+        // Verify user can access the data source (wrapped scoped client enforces tenant/workspace
+        // permissions), then fetch with credentials via an unwrapped scoped repository.
         dataSource = await getDataSource(dataSourceId, savedObjects);
-        if (internalSavedObjects) {
-          dataSource = await getDataSourceInternal(dataSourceId, internalSavedObjects);
+        if (credentialSavedObjects) {
+          dataSource = await getDataSourceWithCredentials(dataSourceId, credentialSavedObjects);
         }
       } else {
         dataSource = testClientDataSourceAttr;
@@ -77,11 +77,11 @@ export const configureClient = async (
       // Verify user can access the data source (scoped client enforces tenant/workspace permissions).
       // This throws a 404 / Forbidden if the user does not have access, preventing use of a
       // data source the caller is not authorised to access.
-      // The scoped client returns credentials stripped by the wrapper; if an internal repository
-      // is available, use it to re-fetch with full encrypted credentials for decryption below.
+      // The wrapped scoped client returns credentials stripped by the wrapper; if an unwrapped
+      // scoped repository is available, use it to re-fetch with full encrypted credentials.
       dataSource = await getDataSource(dataSourceId!, savedObjects);
-      if (internalSavedObjects) {
-        dataSource = await getDataSourceInternal(dataSourceId!, internalSavedObjects);
+      if (credentialSavedObjects) {
+        dataSource = await getDataSourceWithCredentials(dataSourceId!, credentialSavedObjects);
       }
     }
 

--- a/src/plugins/data_source/server/client/configure_client_utils.ts
+++ b/src/plugins/data_source/server/client/configure_client_utils.ts
@@ -71,18 +71,18 @@ export const getDataSource = async (
 };
 
 /**
- * Fetch a data source with full credentials using the internal repository.
- * The internal repository bypasses the credential-stripping SavedObjects wrapper,
+ * Fetch a data source with full credentials using a request-scoped repository.
+ * The repository bypasses the credential-stripping SavedObjects wrapper,
  * so encrypted credentials are present in the returned attributes.
  *
  * IMPORTANT: callers MUST have already verified the requesting user can access
  * this data source via the scoped client (getDataSource) before calling this.
  */
-export const getDataSourceInternal = async (
+export const getDataSourceWithCredentials = async (
   dataSourceId: string,
-  internalSavedObjects: ISavedObjectsRepository
+  credentialSavedObjects: ISavedObjectsRepository
 ): Promise<DataSourceAttributes> => {
-  const dataSourceSavedObject = await internalSavedObjects.get<DataSourceAttributes>(
+  const dataSourceSavedObject = await credentialSavedObjects.get<DataSourceAttributes>(
     DATA_SOURCE_SAVED_OBJECT_TYPE,
     dataSourceId
   );

--- a/src/plugins/data_source/server/legacy/configure_legacy_client.ts
+++ b/src/plugins/data_source/server/legacy/configure_legacy_client.ts
@@ -33,7 +33,7 @@ import {
   getAWSCredential,
   getCredential,
   getDataSource,
-  getDataSourceInternal,
+  getDataSourceWithCredentials,
   getAuthenticationMethod,
   generateCacheKey,
 } from '../client/configure_client_utils';
@@ -43,7 +43,7 @@ export const configureLegacyClient = async (
   {
     dataSourceId,
     savedObjects,
-    internalSavedObjects,
+    credentialSavedObjects,
     cryptography,
     customApiSchemaRegistryPromise,
     request,
@@ -55,13 +55,14 @@ export const configureLegacyClient = async (
   logger: Logger
 ) => {
   try {
-    // Verify the user can access the data source via the scoped client (enforces tenant/workspace
-    // permissions), then fetch with full credentials via internal repository.
-    // The scoped client returns credentials stripped by the wrapper; re-fetch via internal
-    // repository when available so encrypted credentials are present for decryption below.
+    // Verify the user can access the data source via the wrapped scoped client (enforces
+    // tenant/workspace permissions), then fetch with full credentials via an unwrapped scoped
+    // repository.
+    // The wrapped client returns credentials stripped; re-fetch via the unwrapped repository
+    // when available so encrypted credentials are present for decryption below.
     let dataSourceAttr = await getDataSource(dataSourceId!, savedObjects);
-    if (internalSavedObjects) {
-      dataSourceAttr = await getDataSourceInternal(dataSourceId!, internalSavedObjects);
+    if (credentialSavedObjects) {
+      dataSourceAttr = await getDataSourceWithCredentials(dataSourceId!, credentialSavedObjects);
     }
     let clientParams;
 

--- a/src/plugins/data_source/server/plugin.test.ts
+++ b/src/plugins/data_source/server/plugin.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  coreMock,
+  httpServerMock,
+  savedObjectsClientMock,
+  savedObjectsRepositoryMock,
+} from '../../../../src/core/server/mocks';
+import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../common';
+import { DataSourcePlugin } from './plugin';
+
+describe('DataSourcePlugin', () => {
+  it('uses an unwrapped repository scoped to the request when fetching credentials', async () => {
+    const initializerContext = coreMock.createPluginInitializerContext();
+    const plugin = new DataSourcePlugin(initializerContext);
+    const coreStart = coreMock.createStart();
+    const credentialSavedObjects = savedObjectsRepositoryMock.create();
+    coreStart.savedObjects.createScopedRepository.mockReturnValue(credentialSavedObjects);
+    plugin.start(coreStart);
+
+    const getDataSourceClient = jest.fn();
+    const getDataSourceLegacyClient = jest.fn();
+    const dataSourceService = {
+      getDataSourceClient,
+      getDataSourceLegacyClient,
+    };
+    const provider = (plugin as any).createDataSourceRouteHandlerContext(
+      dataSourceService,
+      {},
+      initializerContext.logger.get(),
+      Promise.resolve({ asScoped: jest.fn().mockReturnValue({ add: jest.fn() }) }),
+      Promise.resolve({}),
+      Promise.resolve({})
+    );
+    const request = httpServerMock.createOpenSearchDashboardsRequest();
+    const savedObjects = savedObjectsClientMock.create();
+
+    const context = await provider(
+      {
+        core: {
+          savedObjects: {
+            client: savedObjects,
+          },
+        },
+      },
+      request
+    );
+    await context.opensearch.getClient('data-source-id');
+    await context.opensearch.legacy.getClient('legacy-data-source-id');
+
+    expect(coreStart.savedObjects.createScopedRepository).toHaveBeenCalledTimes(2);
+    expect(coreStart.savedObjects.createScopedRepository).toHaveBeenNthCalledWith(1, request, [
+      DATA_SOURCE_SAVED_OBJECT_TYPE,
+    ]);
+    expect(coreStart.savedObjects.createScopedRepository).toHaveBeenNthCalledWith(2, request, [
+      DATA_SOURCE_SAVED_OBJECT_TYPE,
+    ]);
+    expect(coreStart.savedObjects.createInternalRepository).not.toHaveBeenCalled();
+    expect(getDataSourceClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dataSourceId: 'data-source-id',
+        savedObjects,
+        credentialSavedObjects,
+        request,
+      })
+    );
+    expect(getDataSourceLegacyClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dataSourceId: 'legacy-data-source-id',
+        savedObjects,
+        credentialSavedObjects,
+        request,
+      })
+    );
+  });
+});

--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -11,7 +11,6 @@ import {
   CoreSetup,
   CoreStart,
   IContextProvider,
-  ISavedObjectsRepository,
   Logger,
   LoggerContextConfigInput,
   OpenSearchDashboardsRequest,
@@ -43,7 +42,7 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
   private started = false;
   private authMethodsRegistry = new AuthenticationMethodRegistry();
   private customApiSchemaRegistry = new CustomApiSchemaRegistry();
-  private internalSavedObjects: ISavedObjectsRepository | undefined;
+  private createScopedRepository: CoreStart['savedObjects']['createScopedRepository'] | undefined;
 
   constructor(private initializerContext: PluginInitializerContext<DataSourcePluginConfigType>) {
     this.logger = this.initializerContext.logger.get();
@@ -181,12 +180,10 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
   public start(core: CoreStart) {
     this.logger.debug('dataSource: Started');
     this.started = true;
-    // Create an internal repository that bypasses the credential-stripping SavedObjects wrapper.
-    // Used exclusively by getClient / getLegacyClient to read encrypted credentials after the
-    // scoped client has already confirmed the calling user has access to the data source.
-    this.internalSavedObjects = core.savedObjects.createInternalRepository([
-      DATA_SOURCE_SAVED_OBJECT_TYPE,
-    ]);
+    // Retain the repository factory so getClient / getLegacyClient can read encrypted credentials
+    // without the credential-stripping SavedObjects wrapper while preserving the request's user,
+    // tenant, and workspace context.
+    this.createScopedRepository = core.savedObjects.createScopedRepository;
     // backendCompatibility (when enabled) registers a custom Transport on core's client.
     // Apply the same Transport to modern data-source clients so legacy ES (6.x/7.x)
     // connections get identical request/response interception (e.g. /_resolve/index
@@ -223,7 +220,9 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
             return dataSourceService.getDataSourceClient({
               dataSourceId,
               savedObjects: context.core.savedObjects.client,
-              internalSavedObjects: this.internalSavedObjects,
+              credentialSavedObjects: this.createScopedRepository?.(req, [
+                DATA_SOURCE_SAVED_OBJECT_TYPE,
+              ]),
               cryptography,
               customApiSchemaRegistryPromise,
               request: req,
@@ -235,7 +234,9 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
               return dataSourceService.getDataSourceLegacyClient({
                 dataSourceId,
                 savedObjects: context.core.savedObjects.client,
-                internalSavedObjects: this.internalSavedObjects,
+                credentialSavedObjects: this.createScopedRepository?.(req, [
+                  DATA_SOURCE_SAVED_OBJECT_TYPE,
+                ]),
                 cryptography,
                 customApiSchemaRegistryPromise,
                 request: req,

--- a/src/plugins/data_source/server/types.ts
+++ b/src/plugins/data_source/server/types.ts
@@ -33,8 +33,8 @@ export interface LegacyClientCallAPIParams {
 export interface DataSourceClientParams {
   // to fetch data source on behalf of users, caller should pass scoped saved objects client
   savedObjects: SavedObjectsClientContract;
-  // internal repository used to read encrypted credentials; bypasses the credential-stripping wrapper
-  internalSavedObjects?: ISavedObjectsRepository;
+  // request-scoped repository used to read encrypted credentials without SavedObjects wrappers
+  credentialSavedObjects?: ISavedObjectsRepository;
   cryptography: CryptographyServiceSetup;
   // optional when creating test client, required for normal client
   dataSourceId?: string;


### PR DESCRIPTION
## Summary

- retain the request-scoped saved objects repository factory in the data source plugin
- use an unwrapped repository scoped to the current request when retrieving encrypted data source credentials
- preserve the wrapped saved objects client as the authorization gate
- add regression coverage for both modern and legacy data source clients

## Root cause

OpenSearch-Dashboards #12258 added the correct caller-scoped access check before retrieving data source credentials. The subsequent credential lookup used `createInternalRepository()`, however, which does not retain the request's user, tenant, or workspace context.

With Security multitenancy enabled, a data source saved in the caller's private tenant therefore passed the initial access check but failed the credential lookup with `Saved object [data-source/<id>] not found`.

This change performs the second lookup through an unwrapped `createScopedRepository(request, ...)`. It bypasses the credential-stripping wrapper while retaining the original request context. The initial wrapped lookup remains in place to enforce access control.

## Validation

- focused data source Jest tests: 4 suites, 63 tests passed
- security-dashboards-plugin multi-data-source integration block: all 6 tests passed against two local OpenSearch clusters
- private-tenant remote data source request returned `200`
- the same data source ID from the global tenant returned the expected `404`
- ESLint passed
- Prettier passed
- patched `dataSource` production bundle compiled successfully
